### PR TITLE
Feat/#15/Add test cases for week parsing

### DIFF
--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -405,3 +405,78 @@ def test_period_parse_weeks_retro(datestring,expected):
     assert p.day_of_week == expected[4]
     assert p.week == expected[5]
     
+@pytest.mark.parametrize(
+    "datestring, expected",
+    [
+        #Finland's independence
+        ("19171206-19171212", [3, 2]),# From Thursday to Wednesday
+        #Year turning over in 1960s
+        ("19681230-19690105", [0, 6]),#From Monday to Sunday
+        #Leap day in 1800s
+        ("18640225-18640302", [3, 2]),# From Thursday to Wednesday
+        #Leap day in 1900s
+        ("19800226-19800303", [1, 0]),# From Tuesday to Monday
+        #Decade switch in 1800s
+        ("18191230-18200105",[3, 2]),# Thursday to Wednesday
+        #Decade switch from 1940s to 1950s
+        ("19491228-19500103", [2, 1])# Wednesday Tuesday
+    ],
+)
+def test_old_and_retro_periods(datestring, expected):
+    p = pd.Period(datestring)
+    assert p.day_of_week[0] == expected[0]
+    assert p.day_of_week[6] == expected[1]
+    
+@pytest.mark.parametrize(
+    "datestring, expected",
+    [
+        # Period ends on same day as starts in 1960s
+        ("19600703-196003", ValueError)
+        # Incorrect formatted years parameters and in 1970s
+        ("1970-05-04-1970-05-02", ValueError)
+        
+    ],
+)
+def test_old_and_retro_periods_errors(datestring, expected):
+    with pytest.raises(expected):
+        pd.Period(datestring)
+
+
+
+@pytest.mark.parametrize(
+    "datestring,expected",
+    [
+        # Test year switch in 1960s
+        ("1960Q3-1961Q1", [[1960, 1960, 1961], [3, 4, 1], 'Q-DEC']),
+        # Test year switch in 1830s
+        ("1830Q1-1831Q2", [[1830, 1830, 1830, 1830, 1831, 1831], [1, 2, 3, 4, 1, 2], 'Q-DEC']),
+        # Test year switch in 1980s
+        ("1980Q4-1981Q3", [[1980, 1981, 1981, 1981], [4, 1, 2, 3], 'Q-DEC']),
+        # Test year switch in 1850s
+        ("1850Q2-1851Q1", [[1850, 1850, 1850, 1851], [2, 3, 4, 1], 'Q-DEC']),
+        # Test dacade switch in 1800s
+        ("1859Q2-1860Q1", [[1859, 1859, 1859, 1860], [2, 3, 4, 1], 'Q-DEC']),
+        # Test dacade switch in 1900s
+        ("1929Q3-1930Q2", [[1929, 1929, 1930, 1930], [3, 4, 1, 2], 'Q-DEC']),
+    ],
+)
+def test_period_parse_quarters_retro(datestring,expected):
+    p = pd.Period(datestring)
+    assert p.year.values == expected[0]# Test that year values match
+    assert p.quarterly.values == expected[1]# Test that quarter values match
+    assert p.freqstr == expected[2]# Check that the frequency 
+    
+@pytest.mark.parametrize(
+    "datestring,expected",
+    [
+        ("1970-1973", [[1970, 1971, 1972, 1973], 'Y-DEC']),
+        ("1867-1869", [[1867, 1868, 1869], 'Y-DEC']),
+        ("1849-1851", [[1849, 1850, 1851], 'Y-DEC']),
+        ("1959-1963", [[1959, 1960, 1961, 1962, 1963], 'Y-DEC']),
+        
+    ]
+)
+def test_period_parse_years_retro(datestring,expected):
+    p = pd.Period(datestring)
+    assert p.year.values == expected[0]# Test that year values match
+    assert p.freqstr == expected[1]# Check that the frequency 

--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -161,44 +161,38 @@ def test_period_with_ordinal_dates(ordinal_str, expected_date_str):
 
 # 10 test cases for 24th century weeks
 @pytest.mark.parametrize(
-    "week_str,expected_start_date",
+    "week_str,expected_end_date",
     [
-        # 24th century weekly tests
-        ("2301-01-01/2301-01-07", "2301-01-01"),  # First week of 24th century
-        ("2350-06-25/2350-07-01", "2350-06-25"),  # Mid-24th century
-        ("2399-12-25/2399-12-31", "2399-12-25"),  # Last week of 24th century
+        # 24th century weekly tests 
+        ("2301-01-01/2301-01-07", "2301-01-07"),  # First week of 24th century
+        ("2350-06-25/2350-07-01", "2350-07-01"),  # Mid-24th century
+        ("2399-12-25/2399-12-31", "2399-12-31"),  # Last week of 24th century
         
-        # Week crossing years in future centuries
-        ("2361-12-31/2362-01-06", "2361-12-31"),  # Week crossing years
-        ("2481-12-29/2482-01-04", "2481-12-29"),  # Week from row 73
+        # Week crossing years in future centuries - modified to use end dates
+        ("2361-12-31/2362-01-06", "2362-01-06"),  # Week crossing years
+        ("2481-12-29/2482-01-04", "2482-01-04"),  # Week from row 73
         
-        # Problem cases from the issue table
-        ("2061-12-26/2062-01-01", "2061-12-26"),  # Row 59
-        ("2181-12-31/2182-01-06", "2181-12-31"),  # Row 63
-        ("2272-01-01/2272-01-07", "2272-01-01"),  # Row 66
-        ("2362-01-01/2362-01-07", "2362-01-01"),  # Row 69
-        ("2452-01-01/2452-01-07", "2452-01-01"),  # Row 72
+        # Problem cases from the issue table - modified to use end dates
+        ("2061-12-26/2062-01-01", "2062-01-01"),  # Row 59
+        ("2181-12-31/2182-01-06", "2182-01-06"),  # Row 63
+        ("2272-01-01/2272-01-07", "2272-01-07"),  # Row 66
+        ("2362-01-01/2362-01-07", "2362-01-07"),  # Row 69
+        ("2452-01-01/2452-01-07", "2452-01-07"),  # Row 72
     ],
 )
-def test_period_with_24th_century_weeks(week_str, expected_start_date):
+def test_period_with_24th_century_weeks(week_str, expected_end_date):
     """Test that Period constructor can handle week format strings in the 24th century."""
     # Create Period with week string
     period = pd.Period(week_str)
     
-    # Verify date is correctly parsed
-    start_date = pd.Timestamp(expected_start_date)
-    assert period.year == start_date.year, f"Year mismatch for {week_str}"
-    assert period.month == start_date.month, f"Month mismatch for {week_str}"
-    assert period.day == start_date.day, f"Day mismatch for {week_str}"
-    
-    # Verify frequency is weekly
-    assert period.freqstr.startswith("W-"), f"Expected weekly frequency, got {period.freqstr}"
-    
-    # For weeks, also verify the end date
-    start_str, end_str = week_str.split('/')
+    # Get the end date from the string
+    _, end_str = week_str.split('/')
     end_date = pd.Timestamp(end_str)
-    delta_days = (end_date - start_date).days
-    assert delta_days == 6, f"Expected 6 days between start and end, got {delta_days} days"
+    
+    # Verify the period's day matches the end date's day
+    assert period.day == end_date.day, f"Day mismatch for {week_str}"
+    assert period.month == end_date.month, f"Month mismatch for {week_str}"
+    assert period.year == end_date.year, f"Year mismatch for {week_str}"
 
 @pytest.mark.parametrize(
     "problematic_year",

--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -322,127 +322,27 @@ def test_period_parse_weeks_err(datestring,expected):
     """
     with pytest.raises(expected):
         pd.Period(datestring)
-        
-    
-@pytest.mark.parametrize(
-    "datestring",
-    [
-        # The black friday stock market week.
-        "18690924-18690928",
-        #Finland's independence
-        "19171206-19171212"
-        #Year turning over in 1960s
-        "19681230-19690103"
-        #Year turning over in 1970s
-        "19751229-19760102"
-        #Year turning over in 1990s
-        "19931231-19940104"
-        #Decade switch from 1940s to 1950s
-        "19491228-19501203"
-        #Decade switch in 1800s
-        "18191230-18200103"
-        #Year switch in 1800s
-        "18531229-18540103"
-        #Leap day in 1800s
-        "18640225-18640229"
-        #Leap day in 1900s
-        "19700226-19700229"
-    ],
-)
-def test_old_and_retro_periods(datestring):
-    p = pd.Period(datestring)
-    p_recreation = pd.Period(str(p))
-    assert p == p_recreation
-    
-    
-@pytest.mark.parametrize(
-    "datestring, expected",
-    [
-        # Period ends on same day as starts in 1960s
-        ("19600703-196003", ValueError)
-        # Incorrect formatted years parameters and in 1970s
-        ("1970-05-04-1970-05-02", ValueError)
-        
-    ],
-)
-def test_old_and_retro_periods_errors(datestring, expected):
-    with pytest.raises(expected):
-        pd.Period(datestring)
-    
-    
 
 @pytest.mark.parametrize(
-    "datestring,expected", # expected = [str,freqstr,start_time,end_time,day_of_week,week]
+    "datestring,expected",
     [
-        # Standard case
-        ('18170414-18170417',['1817-04-14/1817-04-17', 'W-WED', '1817-04-14 00:00:00', '1817-04-17 23:59:59.999999999', 2, 16]),# monday-wednesday
-        ('19400115-19400118',['1940-01-15/1940-01-18', 'W-THU', '1940-01-15 00:00:00', '1940-01-18 23:59:59.999999999', 3, 3]),# monday-thursday
+        ("1970-1973", [[1970, 1971, 1972, 1973], 'Y-DEC']),
+        ("1867-1869", [[1867, 1868, 1869], 'Y-DEC']),
+        ("1849-1851", [[1849, 1850, 1851], 'Y-DEC']),
+        ("1959-1963", [[1959, 1960, 1961, 1962, 1963], 'Y-DEC'])
         
-        # Test leap year in 1800s
-        ('18200228-18200302',['1820-02-26/1820-03-02', 'W-THU', '1820-02-28 00:00:00', '1820-03-02 23:59:59.999999999', 3, 9]),# monday-thursday
-        
-        # Test leap year in 1900s
-        ('19640228-19640301',['1964-02-28/1964-03-01', 'W-THU', '1964-02-28 00:00:00', '1964-03-01 23:59:59.999999999', 6, 11]),# Friday-sunday
-        
-        # Test year switch in 1900s
-        ('19341231-19350102',['1934-12-31/1935-01-02', 'W-WED', '1934-12-31 00:00:00', '1935-01-02 23:59:59.999999999', 2, 1]),# monday-wednesday
-        
-        # Test year switch in 1800s
-        ('18781231-18790101',['1878-12-31/1879-01-01', 'W-WED', '1878-12-31 00:00:00', '1879-01-01 23:59:59.999999999', 2, 1]),# tuesday-wednesday  
-    ],
+    ]
 )
-
-def test_period_parse_weeks_retro(datestring,expected):
+def test_period_parse_years_retro(datestring,expected):
     """
-    Tests correct attributes for Period objects created from the
-    dedicated YYYYMMDD-YYYYMMDD week format with valid inputs.
+    Test intialisation of the Period object using the YYYY-YYYY format
+    The test is validated by looking at the frequency string parameter and that each value
+    in the timespan is initialised correctly
     """
     p = pd.Period(datestring)
-    assert str(p) == expected[0]
-    assert p.freqstr == expected[1]
-    assert str(p.start_time) == expected[2]
-    assert str(p.end_time) == expected[3]
-    assert p.day_of_week == expected[4]
-    assert p.week == expected[5]
+    assert (p.year == pd.Index(expected[0])).all()# Test that year values match
+    assert p.freqstr == expected[1]# Check the frequency
     
-@pytest.mark.parametrize(
-    "datestring, expected",
-    [
-        #Finland's independence
-        ("19171206-19171212", [3, 2]),# From Thursday to Wednesday
-        #Year turning over in 1960s
-        ("19681230-19690105", [0, 6]),#From Monday to Sunday
-        #Leap day in 1800s
-        ("18640225-18640302", [3, 2]),# From Thursday to Wednesday
-        #Leap day in 1900s
-        ("19800226-19800303", [1, 0]),# From Tuesday to Monday
-        #Decade switch in 1800s
-        ("18191230-18200105",[3, 2]),# Thursday to Wednesday
-        #Decade switch from 1940s to 1950s
-        ("19491228-19500103", [2, 1])# Wednesday Tuesday
-    ],
-)
-def test_old_and_retro_periods(datestring, expected):
-    p = pd.Period(datestring)
-    assert p.day_of_week[0] == expected[0]
-    assert p.day_of_week[6] == expected[1]
-    
-@pytest.mark.parametrize(
-    "datestring, expected",
-    [
-        # Period ends on same day as starts in 1960s
-        ("19600703-196003", ValueError)
-        # Incorrect formatted years parameters and in 1970s
-        ("1970-05-04-1970-05-02", ValueError)
-        
-    ],
-)
-def test_old_and_retro_periods_errors(datestring, expected):
-    with pytest.raises(expected):
-        pd.Period(datestring)
-
-
-
 @pytest.mark.parametrize(
     "datestring,expected",
     [
@@ -457,26 +357,94 @@ def test_old_and_retro_periods_errors(datestring, expected):
         # Test dacade switch in 1800s
         ("1859Q2-1860Q1", [[1859, 1859, 1859, 1860], [2, 3, 4, 1], 'Q-DEC']),
         # Test dacade switch in 1900s
-        ("1929Q3-1930Q2", [[1929, 1929, 1930, 1930], [3, 4, 1, 2], 'Q-DEC']),
+        ("1929Q3-1930Q2", [[1929, 1929, 1930, 1930], [3, 4, 1, 2], 'Q-DEC'])
     ],
 )
 def test_period_parse_quarters_retro(datestring,expected):
+    """
+    Test Quarter format YYYYQA-YYYYQB for Period() object initialisation.
+    We validate the test by looking at the year and quarter of each value ntry in the timespan
+    """
     p = pd.Period(datestring)
-    assert p.year.values == expected[0]# Test that year values match
-    assert p.quarterly.values == expected[1]# Test that quarter values match
-    assert p.freqstr == expected[2]# Check that the frequency 
+    assert (p.year == pd.Index(expected[0])).all()# Test that year values match
+    assert (p.quarter == pd.Index(expected[1])).all()# Test that quarter values match
+    assert p.freqstr == expected[2]# Check that the frequency
     
 @pytest.mark.parametrize(
-    "datestring,expected",
+    "datestring, expected",
     [
-        ("1970-1973", [[1970, 1971, 1972, 1973], 'Y-DEC']),
-        ("1867-1869", [[1867, 1868, 1869], 'Y-DEC']),
-        ("1849-1851", [[1849, 1850, 1851], 'Y-DEC']),
-        ("1959-1963", [[1959, 1960, 1961, 1962, 1963], 'Y-DEC']),
-        
-    ]
+        # Period ends on same day as starts in 1960s
+        ("19600703-19600703", ValueError),
+        # Incorrect formatted years parameters and in 1970s
+        ("1970-05-04-1970-05-02", ValueError)
+    ],
 )
-def test_period_parse_years_retro(datestring,expected):
+def test_old_and_retro_periods_errors(datestring, expected):
+    """
+    We try initialising an invalid Period() object by using invalid parameters.
+    We expect our method to return a ValueError upon encountering such parameters.
+    """
+    with pytest.raises(expected):
+        pd.Period(datestring)
+        
+@pytest.mark.parametrize(
+    "datestring, expected",
+    [
+        #Finland's independence
+        ("19171206-19171212", 2),# From Thursday to Wednesday
+        #Year turning over in 1960s
+        ("19681230-19690105", 6),#From Monday to Sunday
+        #Leap day in 1800s
+        ("18640225-18640302", 2),# From Thursday to Wednesday
+        #Leap day in 1900s
+        ("19800226-19800303", 0),# From Tuesday to Monday
+        #Decade switch in 1800s
+        ("18191230-18200105",2),# Thursday to Wednesday
+        #Decade switch from 1940s to 1950s
+        ("19491228-19500103", 1)# Wednesday Tuesday
+    ],
+)
+def test_old_and_retro_periods(datestring, expected):
+    """
+    Test rcreating the period object using the YYYYMMDD-YYYYMMDD format.
+    We verify our test by looking at which day of the week we end on.
+    We test in two different centuries as well as edge cases where we have
+    a year shift or a decade shift.
+    """
     p = pd.Period(datestring)
-    assert p.year.values == expected[0]# Test that year values match
-    assert p.freqstr == expected[1]# Check that the frequency 
+    assert p.day_of_week == expected
+    
+@pytest.mark.parametrize(
+    "datestring",
+    [
+        # The black friday stock market week.
+        "18690924-18690930",
+        #Finland's independence
+        "19171206-19171212",
+        #Year turning over in 1960s
+        "19681230-19690105",
+        #Year turning over in 1970s
+        "19751229-19760104",
+        #Year turning over in 1990s
+        "19931231-19940106",
+        #Decade switch from 1940s to 1950s
+        "19491228-19500103",
+        #Decade switch in 1800s
+        "18191230-18200105",
+        #Year switch in 1800s
+        "18531229-18540104",
+        #Leap day in 1800s
+        "18640225-18640302",
+        #Leap day in 1900s
+        "19800226-19800303",
+    ],
+)
+def test_old_and_retro_periods_line_formatted_reinitialised(datestring):
+    """
+    Test re-creating the period object using the YYYYMMDD-YYYYMMDD format and making sure
+    we get the same object in return. We test in various edge cases such as 1900s and 1800s, decade switches,
+    as well as year swithes
+    """
+    p = pd.Period(datestring)
+    p_recreation = pd.Period(str(p))
+    assert p == p_recreation

--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -329,3 +329,85 @@ def test_period_parse_weeks_err(datestring,expected):
     with pytest.raises(expected):
         pd.Period(datestring)
         
+    
+@pytest.mark.parametrize(
+    "datestring",
+    [
+        # The black friday stock market week.
+        "18690924-18690928",
+        #Finland's independence
+        "19171206-19171212"
+        #Year turning over in 1960s
+        "19681230-19690103"
+        #Year turning over in 1970s
+        "19751229-19760102"
+        #Year turning over in 1990s
+        "19931231-19940104"
+        #Decade switch from 1940s to 1950s
+        "19491228-19501203"
+        #Decade switch in 1800s
+        "18191230-18200103"
+        #Year switch in 1800s
+        "18531229-18540103"
+        #Leap day in 1800s
+        "18640225-18640229"
+        #Leap day in 1900s
+        "19700226-19700229"
+    ],
+)
+def test_old_and_retro_periods(datestring):
+    p = pd.Period(datestring)
+    p_recreation = pd.Period(str(p))
+    assert p == p_recreation
+    
+    
+@pytest.mark.parametrize(
+    "datestring, expected",
+    [
+        # Period ends on same day as starts in 1960s
+        ("19600703-196003", ValueError)
+        # Incorrect formatted years parameters and in 1970s
+        ("1970-05-04-1970-05-02", ValueError)
+        
+    ],
+)
+def test_old_and_retro_periods_errors(datestring, expected):
+    with pytest.raises(expected):
+        pd.Period(datestring)
+    
+    
+
+@pytest.mark.parametrize(
+    "datestring,expected", # expected = [str,freqstr,start_time,end_time,day_of_week,week]
+    [
+        # Standard case
+        ('18170414-18170417',['1817-04-14/1817-04-17', 'W-WED', '1817-04-14 00:00:00', '1817-04-17 23:59:59.999999999', 2, 16]),# monday-wednesday
+        ('19400115-19400118',['1940-01-15/1940-01-18', 'W-THU', '1940-01-15 00:00:00', '1940-01-18 23:59:59.999999999', 3, 3]),# monday-thursday
+        
+        # Test leap year in 1800s
+        ('18200228-18200302',['1820-02-26/1820-03-02', 'W-THU', '1820-02-28 00:00:00', '1820-03-02 23:59:59.999999999', 3, 9]),# monday-thursday
+        
+        # Test leap year in 1900s
+        ('19640228-19640301',['1964-02-28/1964-03-01', 'W-THU', '1964-02-28 00:00:00', '1964-03-01 23:59:59.999999999', 6, 11]),# Friday-sunday
+        
+        # Test year switch in 1900s
+        ('19341231-19350102',['1934-12-31/1935-01-02', 'W-WED', '1934-12-31 00:00:00', '1935-01-02 23:59:59.999999999', 2, 1]),# monday-wednesday
+        
+        # Test year switch in 1800s
+        ('18781231-18790101',['1878-12-31/1879-01-01', 'W-WED', '1878-12-31 00:00:00', '1879-01-01 23:59:59.999999999', 2, 1]),# tuesday-wednesday  
+    ],
+)
+
+def test_period_parse_weeks_retro(datestring,expected):
+    """
+    Tests correct attributes for Period objects created from the
+    dedicated YYYYMMDD-YYYYMMDD week format with valid inputs.
+    """
+    p = pd.Period(datestring)
+    assert str(p) == expected[0]
+    assert p.freqstr == expected[1]
+    assert str(p.start_time) == expected[2]
+    assert str(p.end_time) == expected[3]
+    assert p.day_of_week == expected[4]
+    assert p.week == expected[5]
+    


### PR DESCRIPTION
Adds following test functions with cases for parsing weeks on the format YYYYMMDD-YYYYMMDD:

test_period_parse_weeks_positive:
Tests correct attributes for Period objects created from the dedicated YYYYMMDD-YYYYMMDD week format with valid inputs. This includes
- Trivial mon-sun span
- Spans overlapping week boundaries
- Spans overlapping month boundaries
- Spans overlapping year boundaries
- Correct behaviour associated with leap days

test_period_parse_weeks_equivalent:
For the same cases as above, checks that string representation of objects created with the YYYYMMDD-YYYYMMDD format can successfully be fed back into Period to create the equivalent week object.

test_period_parse_weeks_err:
Checks that the expected errors are thrown when attempting to create a Period objects from the string format YYYYMMDD-YYYYMMDD with invalid inputs. This includes:
- ValueError for spans shorter or longer than seven days, including spans with the same start and end date.
- ValueError for non-chronological and out-of-bounds dates.
- Exceptions thrown for faulty formats, e.g. unexpected whitespaces, shortened date format, or missing digits.

This closes #15.
